### PR TITLE
Pin Kubernetes Python client to working version

### DIFF
--- a/drainer/requirements.txt
+++ b/drainer/requirements.txt
@@ -1,1 +1,1 @@
-kubernetes
+kubernetes==9.0.0


### PR DESCRIPTION
Otherwise, `k8s_config.load_kube_config()` will fail.

Fixes #14 