### PR TITLE
Allow loading of configuration from S3

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ lambda function is running in the correct VPC and subnet.
 This lambda can also be used against a non-EKS Kubernetes cluster by reading a `kubeconfig` file from an S3 bucket
 specified by the `KUBE_CONFIG_BUCKET` and `KUBE_CONFIG_OBJECT` environment variables. If these two variables are passed 
 in then Drainer function will assume this is a non-EKS cluster and the IAM authenticator signatures will _not_ be added 
-to kubernetes API requests. It is recommended to apply the principle of least privilege to the IAM role that governs
+to Kubernetes API requests. It is recommended to apply the principle of least privilege to the IAM role that governs
 access between the Lambda function and S3 bucket.
 
 Below is a brief explanation of the folder structure of the project:

--- a/README.md
+++ b/README.md
@@ -23,6 +23,11 @@ NB: The lambda function created assumes that the Amazon EKS cluster's Kubernetes
 enabled, if your endpoint only has private access enabled then you must modify the `template.yml` file to ensure the 
 lambda function is running in the correct VPC and subnet.
 
+This lambda can also be used against a non-EKS kubernetes cluster, reading a kubeconfig file from an S3 bucket
+specified by the KUBE\_CONFIG\_BUCKET and KUBE\_CONFIG\_OBJECT environment variables. If CLUSTER\_NAME is not passed as
+an environment variable then IAM authenticator signatures will also not be added to kubernetes API requests. At present
+no example for this is provided.
+
 Below is a brief explanation of the folder structure of the project:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ NB: The lambda function created assumes that the Amazon EKS cluster's Kubernetes
 enabled, if your endpoint only has private access enabled then you must modify the `template.yml` file to ensure the 
 lambda function is running in the correct VPC and subnet.
 
-This lambda can also be used against a non-EKS kubernetes cluster, reading a kubeconfig file from an S3 bucket
+This lambda can also be used against a non-EKS Kubernetes cluster by reading a `kubeconfig` file from an S3 bucket
 specified by the `KUBE_CONFIG_BUCKET` and `KUBE_CONFIG_OBJECT` environment variables. If `CLUSTER_NAME` is not passed as
 an environment variable then IAM authenticator signatures will also not be added to kubernetes API requests. At present
 no example for this is provided.

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ enabled, if your endpoint only has private access enabled then you must modify t
 lambda function is running in the correct VPC and subnet.
 
 This lambda can also be used against a non-EKS kubernetes cluster, reading a kubeconfig file from an S3 bucket
-specified by the KUBE\_CONFIG\_BUCKET and KUBE\_CONFIG\_OBJECT environment variables. If CLUSTER\_NAME is not passed as
+specified by the `KUBE_CONFIG_BUCKET` and `KUBE_CONFIG_OBJECT` environment variables. If `CLUSTER_NAME` is not passed as
 an environment variable then IAM authenticator signatures will also not be added to kubernetes API requests. At present
 no example for this is provided.
 

--- a/README.md
+++ b/README.md
@@ -24,9 +24,10 @@ enabled, if your endpoint only has private access enabled then you must modify t
 lambda function is running in the correct VPC and subnet.
 
 This lambda can also be used against a non-EKS Kubernetes cluster by reading a `kubeconfig` file from an S3 bucket
-specified by the `KUBE_CONFIG_BUCKET` and `KUBE_CONFIG_OBJECT` environment variables. If `CLUSTER_NAME` is not passed as
-an environment variable then IAM authenticator signatures will also not be added to kubernetes API requests. At present
-no example for this is provided.
+specified by the `KUBE_CONFIG_BUCKET` and `KUBE_CONFIG_OBJECT` environment variables. If these two variables are passed 
+in then Drainer function will assume this is a non-EKS cluster and the IAM authenticator signatures will _not_ be added 
+to kubernetes API requests. It is recommended to apply the principle of least privilege to the IAM role that governs
+access between the Lambda function and S3 bucket.
 
 Below is a brief explanation of the folder structure of the project:
 

--- a/drainer/handler.py
+++ b/drainer/handler.py
@@ -64,9 +64,11 @@ def create_kube_config(eks):
     with open(KUBE_FILEPATH, 'w') as f:
         yaml.dump(kube_config, f, default_flow_style=False)
 
+
 def get_kube_config(s3):
     """Downloads the Kubernetes config file from S3."""
     s3.download_file(KUBE_CONFIG_BUCKET, KUBE_CONFIG_OBJECT, KUBE_FILEPATH)
+
 
 def get_bearer_token(cluster, region):
     """Creates the authentication to token required by AWS IAM Authenticator. This is
@@ -135,7 +137,7 @@ def _lambda_handler(k8s_config, k8s_client, event):
     # Configure
     k8s_config.load_kube_config(KUBE_FILEPATH)
     configuration = k8s_client.Configuration()
-    if CLUSTER_NAME:
+    if not KUBE_CONFIG_BUCKET:
         configuration.api_key['authorization'] = get_bearer_token(CLUSTER_NAME, REGION)
         configuration.api_key_prefix['authorization'] = 'Bearer'
     # API

--- a/tests/drainer/test_handler.py
+++ b/tests/drainer/test_handler.py
@@ -11,7 +11,6 @@ from tests.utils import dict_to_simple_namespace
 
 @pytest.fixture()
 def handler(monkeypatch):
-    monkeypatch.setenv('CLUSTER_NAME', 'test-cluster')
     monkeypatch.setenv('AWS_REGION', 'eu-west-1')
     import drainer.handler as handler
     return handler
@@ -131,8 +130,24 @@ def mock_ec2(mocker):
 
 
 @pytest.fixture()
+def fake_eks_env():
+    return {
+        'kube_config_bucket': None,
+        'kube_config_object': None,
+        'cluster_name': 'test-cluster'
+    }
+
+@pytest.fixture()
+def fake_noneks_env():
+    return {
+        'kube_config_bucket': 'bucket',
+        'kube_config_object': 'object',
+        'cluster_name': 'test-cluster',
+    }
+
+
+@pytest.fixture()
 def patched_handler(fs, monkeypatch, mocker, mock_eks, mock_ec2):
-    monkeypatch.setenv('CLUSTER_NAME', 'test-cluster')
     monkeypatch.setenv('AWS_REGION', 'eu-west-1')
 
     # pyfakefs always initialises a temp dir, on Mac it is /var on Linux it is /tmp
@@ -146,6 +161,7 @@ def patched_handler(fs, monkeypatch, mocker, mock_eks, mock_ec2):
 
     import drainer.handler as handler
 
+    monkeypatch.setattr(handler, 's3', mocker.Mock())
     monkeypatch.setattr(handler, 'asg', mocker.Mock())
     monkeypatch.setattr(handler, 'ec2', mock_ec2)
     monkeypatch.setattr(handler, 'eks', mock_eks)
@@ -156,7 +172,8 @@ def patched_handler(fs, monkeypatch, mocker, mock_eks, mock_ec2):
 @pytest.fixture()
 def patched_main_handler(mocker, mock_eks, mock_ec2, monkeypatch):
     monkeypatch.setenv('CLUSTER_NAME', 'test-cluster')
-    monkeypatch.setenv('AWS_REGION', 'eu-west-1')
+    monkeypatch.setenv('KUBE_CONFIG_BUCKET', 'bucket')
+    monkeypatch.setenv('KUBE_CONFIG_OBJECT', 'object')
 
     import drainer.handler as handler
 
@@ -200,7 +217,7 @@ def test_create_kube_config(handler, fs, mock_eks):
     kube_config_loc = os.path.join(os.path.dirname(__file__), 'fixtures/kube_config.yaml')
     fs.add_real_file(kube_config_loc)
 
-    handler.create_kube_config(mock_eks)
+    handler.create_kube_config(mock_eks, 'test-cluster')
 
     assert os.path.exists('/tmp/kubeconfig') is True
 
@@ -209,11 +226,11 @@ def test_create_kube_config(handler, fs, mock_eks):
 
 
 @freeze_time("2014-04-09 01:30:00")
-def test_handler(mocker, monkeypatch, patched_handler, mock_k8s_client, mock_event):
+def test_handler_eks(mocker, monkeypatch, patched_handler, fake_eks_env, mock_k8s_client, mock_event):
     monkeypatch.setenv('AWS_ACCESS_KEY_ID', 'fake')
     monkeypatch.setenv('AWS_SECRET_ACCESS_KEY', 'fake')
 
-    patched_handler._lambda_handler(mocker.Mock(), mock_k8s_client, mock_event)
+    patched_handler._lambda_handler(fake_eks_env, mocker.Mock(), mock_k8s_client, mock_event)
 
     bearer_token = 'k8s-aws-v1.aHR0cHM6Ly9zdHMuZXUtd2VzdC0xLmFtYXpvbmF3cy5jb20vP' \
                    '0FjdGlvbj1HZXRDYWxsZXJJZGVudGl0eSZWZXJzaW9uPTIwMTEtMDYtMTUmW' \
@@ -239,11 +256,34 @@ def test_handler(mocker, monkeypatch, patched_handler, mock_k8s_client, mock_eve
                                                                      InstanceId='i-036e525e159f62a5d')
 
 
-def test_handler_no_nodes(mocker, monkeypatch, patched_handler, mock_k8s_client_no_nodes, mock_event):
+def test_handler_noneks(mocker, monkeypatch, patched_handler, fake_noneks_env, mock_k8s_client, mock_event):
     monkeypatch.setenv('AWS_ACCESS_KEY_ID', 'fake')
     monkeypatch.setenv('AWS_SECRET_ACCESS_KEY', 'fake')
 
-    patched_handler._lambda_handler(mocker.Mock(), mock_k8s_client_no_nodes, mock_event)
+    patched_handler._lambda_handler(fake_noneks_env, mocker.Mock(), mock_k8s_client, mock_event)
+
+    patched_handler.s3.download_file.assert_called_with('bucket', 'object', '/tmp/kubeconfig')
+
+    assert mock_k8s_client.Configuration.return_value.api_key.get('authorization') == None
+    assert mock_k8s_client.Configuration.return_value.api_key_prefix.get('authorization') == None
+
+    mock_k8s_client.CoreV1Api.return_value.patch_node.assert_called_with('test_node', mocker.ANY)
+    mock_k8s_client.CoreV1Api.return_value.list_pod_for_all_namespaces.assert_called_with(watch=False,
+                                                                                          include_uninitialized=True,
+                                                                                          field_selector='spec.nodeName=test_node')
+    assert mock_k8s_client.CoreV1Api.return_value.create_namespaced_pod_eviction.call_count == 2
+
+    patched_handler.asg.complete_lifecycle_action.assert_called_with(LifecycleHookName='k8s-drainer-LifecycleHook-DDXJNVV0KBG1',
+                                                                     AutoScalingGroupName='k8s-worker-nodes-dev-NodeGroup-F49231EK31OA',
+                                                                     LifecycleActionResult='CONTINUE',
+                                                                     InstanceId='i-036e525e159f62a5d')
+
+
+def test_handler_no_nodes(mocker, monkeypatch, patched_handler, fake_eks_env, mock_k8s_client_no_nodes, mock_event):
+    monkeypatch.setenv('AWS_ACCESS_KEY_ID', 'fake')
+    monkeypatch.setenv('AWS_SECRET_ACCESS_KEY', 'fake')
+
+    patched_handler._lambda_handler(fake_eks_env, mocker.Mock(), mock_k8s_client_no_nodes, mock_event)
 
     patched_handler.asg.complete_lifecycle_action.assert_called_with(LifecycleHookName='k8s-drainer-LifecycleHook-DDXJNVV0KBG1',
                                                                      AutoScalingGroupName='k8s-worker-nodes-dev-NodeGroup-F49231EK31OA',
@@ -251,11 +291,11 @@ def test_handler_no_nodes(mocker, monkeypatch, patched_handler, mock_k8s_client_
                                                                      InstanceId='i-036e525e159f62a5d')
 
 
-def test_handler_patch_exception(mocker, monkeypatch, patched_handler, mock_k8s_client_patch_exception, mock_event):
+def test_handler_patch_exception(mocker, monkeypatch, patched_handler, fake_eks_env, mock_k8s_client_patch_exception, mock_event):
     monkeypatch.setenv('AWS_ACCESS_KEY_ID', 'fake')
     monkeypatch.setenv('AWS_SECRET_ACCESS_KEY', 'fake')
 
-    patched_handler._lambda_handler(mocker.Mock(), mock_k8s_client_patch_exception, mock_event)
+    patched_handler._lambda_handler(fake_eks_env, mocker.Mock(), mock_k8s_client_patch_exception, mock_event)
 
     patched_handler.asg.complete_lifecycle_action.assert_called_with(LifecycleHookName='k8s-drainer-LifecycleHook-DDXJNVV0KBG1',
                                                                      AutoScalingGroupName='k8s-worker-nodes-dev-NodeGroup-F49231EK31OA',
@@ -263,11 +303,11 @@ def test_handler_patch_exception(mocker, monkeypatch, patched_handler, mock_k8s_
                                                                      InstanceId='i-036e525e159f62a5d')
 
 
-def test_handler_pods_exception(mocker, monkeypatch, patched_handler, mock_k8s_client_pods_exception, mock_event):
+def test_handler_pods_exception(mocker, monkeypatch, patched_handler, fake_eks_env, mock_k8s_client_pods_exception, mock_event):
     monkeypatch.setenv('AWS_ACCESS_KEY_ID', 'fake')
     monkeypatch.setenv('AWS_SECRET_ACCESS_KEY', 'fake')
 
-    patched_handler._lambda_handler(mocker.Mock(), mock_k8s_client_pods_exception, mock_event)
+    patched_handler._lambda_handler(fake_eks_env, mocker.Mock(), mock_k8s_client_pods_exception, mock_event)
 
     patched_handler.asg.complete_lifecycle_action.assert_called_with(LifecycleHookName='k8s-drainer-LifecycleHook-DDXJNVV0KBG1',
                                                                      AutoScalingGroupName='k8s-worker-nodes-dev-NodeGroup-F49231EK31OA',
@@ -278,5 +318,10 @@ def test_handler_pods_exception(mocker, monkeypatch, patched_handler, mock_k8s_c
 def test_main_handler(patched_main_handler, mock_event):
     patched_main_handler.lambda_handler(mock_event, {})
     k8s = patched_main_handler.k8s
+    env = {
+        'cluster_name': 'test-cluster',
+        'kube_config_bucket': 'bucket',
+        'kube_config_object': 'object'
+    }
 
-    patched_main_handler._lambda_handler.assert_called_with(k8s.config, k8s.client, mock_event)
+    patched_main_handler._lambda_handler.assert_called_with(env, k8s.config, k8s.client, mock_event)


### PR DESCRIPTION
*Description of changes:*

This PR finishes the work began in #12, which allows the Drainer to support non-EKS clusters if the user puts their kubeconfig file in s3.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
