### PR TITLE
Correctly Evict Pods For >= v1.16

### DIFF
--- a/drainer/handler.py
+++ b/drainer/handler.py
@@ -140,6 +140,8 @@ def _lambda_handler(env, k8s_config, k8s_client, event):
     api = k8s_client.ApiClient(configuration)
     v1 = k8s_client.CoreV1Api(api)
 
+    cluster_version = eks.describe_cluster(name=cluster_name)['cluster']['version']
+
     try:
         if not node_exists(v1, node_name):
             logger.error('Node not found.')
@@ -148,7 +150,7 @@ def _lambda_handler(env, k8s_config, k8s_client, event):
 
         cordon_node(v1, node_name)
 
-        remove_all_pods(v1, node_name)
+        remove_all_pods(v1, node_name, cluster_version)
 
         asg.complete_lifecycle_action(LifecycleHookName=lifecycle_hook_name,
                                       AutoScalingGroupName=auto_scaling_group_name,

--- a/tests/drainer/test_handler.py
+++ b/tests/drainer/test_handler.py
@@ -8,6 +8,15 @@ from kubernetes.client.rest import ApiException
 
 from tests.utils import dict_to_simple_namespace
 
+describe_cluster_response = {
+    'cluster': {
+        'version': '1.15',
+        'certificateAuthority': {
+            'data': '84586abd904ef'
+        },
+        'endpoint': 'https://test-cluster.amazonaws.com'
+     }
+}
 
 @pytest.fixture()
 def handler(monkeypatch):
@@ -15,16 +24,9 @@ def handler(monkeypatch):
     import drainer.handler as handler
     return handler
 
-
 @pytest.fixture()
 def mock_eks(mocker):
-    return mocker.Mock(**{'describe_cluster.return_value': {'cluster': {
-        'version': '1.15',
-        'certificateAuthority': {
-            'data': '84586abd904ef'
-        },
-        'endpoint': 'https://test-cluster.amazonaws.com'
-    }}})
+    return mocker.Mock(**{'describe_cluster.return_value': describe_cluster_response})
 
 
 @pytest.fixture()
@@ -218,7 +220,7 @@ def test_create_kube_config(handler, fs, mock_eks):
     kube_config_loc = os.path.join(os.path.dirname(__file__), 'fixtures/kube_config.yaml')
     fs.add_real_file(kube_config_loc)
 
-    handler.create_kube_config(mock_eks, 'test-cluster')
+    handler.create_kube_config(mock_eks, describe_cluster_response['cluster'])
 
     assert os.path.exists('/tmp/kubeconfig') is True
 

--- a/tests/drainer/test_handler.py
+++ b/tests/drainer/test_handler.py
@@ -19,6 +19,7 @@ def handler(monkeypatch):
 @pytest.fixture()
 def mock_eks(mocker):
     return mocker.Mock(**{'describe_cluster.return_value': {'cluster': {
+        'version': '1.15',
         'certificateAuthority': {
             'data': '84586abd904ef'
         },


### PR DESCRIPTION
*Issue #, if available*

Fixes https://github.com/aws-samples/amazon-k8s-node-drainer/issues/27

*Description of changes:*

Allows for the eviction of pods for Kubernetes 1.16+. Functionally tested against a 1.16 cluster.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
