### PR TITLE
Fix for kubernetes api failure: eviction object name and pod should match

### DIFF
--- a/drainer/k8s_utils.py
+++ b/drainer/k8s_utils.py
@@ -81,7 +81,7 @@ def evict_pods(api, pods):
             }
         }
         try:
-            api.create_namespaced_pod_eviction(pod.metadata.name + '-eviction', pod.metadata.namespace, body)
+            api.create_namespaced_pod_eviction(pod.metadata.name, pod.metadata.namespace, body)
         except ApiException as err:
             if err.status == 429:
                 remaining.append(pod)


### PR DESCRIPTION
*Description of changes:*
Kubernetes API denied the calls for eviction objects (on EKS 1.16) since the eviction object name should match the pod name which it scopes to

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
