### PR TITLE
Fix for kubernetes api failure: eviction object name should match pod name as of 1.16 (prior to that it could be anything)

### DIFF
--- a/drainer/k8s_utils.py
+++ b/drainer/k8s_utils.py
@@ -81,7 +81,7 @@ def evict_pods(api, pods):
             }
         }
         try:
-            api.create_namespaced_pod_eviction(pod.metadata.name + '-eviction', pod.metadata.namespace, body)
+            api.create_namespaced_pod_eviction(pod.metadata.name, pod.metadata.namespace, body)
         except ApiException as err:
             if err.status == 429:
                 remaining.append(pod)

--- a/tests/drainer/test_k8s_utils.py
+++ b/tests/drainer/test_k8s_utils.py
@@ -89,8 +89,8 @@ def test_remove_all_pods(mocker):
         }
     }
 
-    mock_api.create_namespaced_pod_eviction.assert_any_call('test_pod1-eviction', 'test_ns', mock_arg)
-    mock_api.create_namespaced_pod_eviction.assert_any_call('test_pod2-eviction', 'test_ns', mock_arg1)
+    mock_api.create_namespaced_pod_eviction.assert_any_call('test_pod1', 'test_ns', mock_arg)
+    mock_api.create_namespaced_pod_eviction.assert_any_call('test_pod2', 'test_ns', mock_arg1)
 
 
 def test_remove_disruption_failure(mocker):
@@ -125,8 +125,8 @@ def test_remove_disruption_failure(mocker):
     }
 
     mock_api.create_namespaced_pod_eviction.assert_has_calls([
-        call('test_pod1-eviction', 'test_ns', mock_arg),
-        call('test_pod1-eviction', 'test_ns', mock_arg)]
+        call('test_pod1', 'test_ns', mock_arg),
+        call('test_pod1', 'test_ns', mock_arg)]
     )
 
 
@@ -163,7 +163,7 @@ def test_remove_pending(mocker):
         }
     }
 
-    mock_api.create_namespaced_pod_eviction.assert_any_call('test_pod1-eviction', 'test_ns', mock_arg)
+    mock_api.create_namespaced_pod_eviction.assert_any_call('test_pod1', 'test_ns', mock_arg)
 
 
 def test_skip_daemonsets(mocker):
@@ -220,7 +220,7 @@ def test_skip_daemonsets(mocker):
         }
     }
 
-    mock_api.create_namespaced_pod_eviction.assert_any_call('test_pod2-eviction', 'test_ns', mock_arg1)
+    mock_api.create_namespaced_pod_eviction.assert_any_call('test_pod2', 'test_ns', mock_arg1)
 
 def test_skip_mirror_pods(mocker):
     list_pods_val = dict_to_simple_namespace({'items': [
@@ -270,4 +270,4 @@ def test_skip_mirror_pods(mocker):
         }
     }
 
-    mock_api.create_namespaced_pod_eviction.assert_any_call('test_pod2-eviction', 'test_ns', mock_arg1)
+    mock_api.create_namespaced_pod_eviction.assert_any_call('test_pod2', 'test_ns', mock_arg1)


### PR DESCRIPTION
Description of changes:
Kubernetes API denied the calls for eviction objects (on EKS 1.16) since the eviction object name should match the pod name which it scopes to

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.