### PR TITLE
feature/fix Completed Job pods cause an error

### DIFF
--- a/drainer/k8s_utils.py
+++ b/drainer/k8s_utils.py
@@ -49,6 +49,13 @@ def pod_is_evictable(pod):
             if ref.kind == CONTROLLER_KIND_DAEMON_SET:
                 logger.info("Skipping DaemonSet {}/{}".format(pod.metadata.namespace, pod.metadata.name))
                 return False
+            if pod.status and pod.status.phase:
+                if pod.status.phase == "Failed":
+                    logger.info("Skipping failed pod {}/{}".format(pod.metadata.namespace, pod.metadata.name))
+                    return False
+                elif pod.status.phase == "Succeeded":
+                    logger.info("Skipping succeeded pod {}/{}".format(pod.metadata.namespace, pod.metadata.name))
+                    return False
     return True
 
 


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws-samples/amazon-k8s-node-drainer/issues/33

*Description of changes:*

We should ignore completed and failed pods as part of node draining. Hence, skipping pods with status phase either `Failed` or `Succeeded`.