### PR TITLE
Add cluster name postfix to the default stack name

### DIFF
--- a/build_deploy.sh
+++ b/build_deploy.sh
@@ -8,4 +8,4 @@ PROFILE=${4:-default}
 
 sam build --use-container --skip-pull-image --profile ${PROFILE}
 sam package --s3-bucket ${BUCKET} --output-template-file packaged.yaml --profile ${PROFILE}
-sam deploy --template-file packaged.yaml --stack-name k8s-drainer --capabilities CAPABILITY_IAM --profile ${PROFILE} --parameter-overrides AutoScalingGroup=${ASG} EksCluster=${CLUSTER}
+sam deploy --template-file packaged.yaml --stack-name k8s-drainer-${CLUSTER} --capabilities CAPABILITY_IAM --profile ${PROFILE} --parameter-overrides AutoScalingGroup=${ASG} EksCluster=${CLUSTER}


### PR DESCRIPTION
Had a problem when deployed drainer twice into 2 different clusters using build_deploy.sh, using the current code it's override the deployed cloudformation stack and affected an already functional cluster.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
